### PR TITLE
Make the port of the incident service configurable

### DIFF
--- a/config/configmap.yml
+++ b/config/configmap.yml
@@ -319,8 +319,8 @@ data:
 
     lnames.file=/deployments/config/LNames.txt
 
-    incident.service=incident-service-naps-emergency-response.apps.753d.openshift.opentlc.com
-
+    incident.service=incident-service.naps-emergency-response.svc
+    incident.port=8080
     incident.uri=/incidents
 
     enabled=false

--- a/src/main/java/com/redhat/cajun/navy/datagenerate/SendIncident.java
+++ b/src/main/java/com/redhat/cajun/navy/datagenerate/SendIncident.java
@@ -13,7 +13,9 @@ import io.vertx.ext.web.client.WebClient;
 public class SendIncident extends AbstractVerticle {
 
     String uri = "/incidents";
-    String host = "incident-service-naps-emergency-response.apps.753d.openshift.opentlc.com";
+    String host = "incident-service.naps-emergency-response.svc";
+    int port = 8080;
+
     WebClient client = null;
     boolean isEnabled = false;
     @Override
@@ -23,6 +25,7 @@ public class SendIncident extends AbstractVerticle {
         client = WebClient.create(vertx);
         host = config().getString("incident.service");
         uri = config().getString("incident.uri");
+        port = config().getInteger("incident.port");
         isEnabled = config().getBoolean("enabled");
         System.out.println("IncidentService located at: "+host + uri);
 
@@ -54,11 +57,10 @@ public class SendIncident extends AbstractVerticle {
 
 
     private void sendRequest(Victim v) {
-
-        System.out.println(host + uri + v);
+        System.out.println(host + ":" + port + uri + v);
         if(isEnabled){
                     client
-                .post(80, host, uri)
+                .post(port, host, uri)
                 .sendJsonObject(JsonObject.mapFrom(v), ar -> {
                             if (ar.succeeded()) {
                                 HttpResponse<Buffer> response = ar.result();


### PR DESCRIPTION
Currently we have hard coded the port of the incident service that
we interact with to 80. However, when using internal service URLs
instead of public Routes it is more likely to be 8080.

To allow for both of these options an `incident.port` configuration
option has been added which defaults to 8080.

The default incident URL has also been made something more generic
instead of referencing a specific cluster. It still references a
specific namespace but this seems to be more generic.